### PR TITLE
Add support for OQMD/MP via generic interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ If all tests sucessfuly pass, _Xerus_ should be ready for use.
 If you use _Xerus_ please __also__ cite the following papers:
 
 * If you use only phase matching:
-  * Pedro Baptista de Castro, Kensei Terashima, Miren Garbiñe Esparza Echevarría, Hiroyuki Takeya, Yoshihiko Takano (2021). "XERUS: An open-source tool for quick XRD phase identification and refinement automation" arXiv:2112.04773, https://arxiv.org/abs/2112.04773
+  * Baptista de Castro, P., Terashima, K., Esparza Echevarria, M.G., Takeya, H. and Takano, Y. (2022), XERUS: An Open-Source Tool for Quick XRD Phase Identification and Refinement Automation. Adv. Theory Simul. 2100588. https://doi.org/10.1002/adts.202100588
   * Toby, B. H., & Von Dreele, R. B. (2013). "GSAS-II: the genesis of a modern open-source all purpose crystallography software package". Journal of Applied Crystallography, 46(2), 544-549. ​doi:10.1107/S0021889813003531
 
 

--- a/Xerus/queriers/multiquery.py
+++ b/Xerus/queriers/multiquery.py
@@ -23,21 +23,23 @@ import sys
 from pathlib import Path
 from typing import List
 
-from Xerus.queriers.optimade import OptimadeQuery
 project_path = str(Path(os.path.dirname(os.path.realpath(__file__))).parent) + os.sep # so convoluted..
 if project_path not in sys.path:
     sys.path.append(project_path)
-from Xerus.queriers.mp import querymp
-from Xerus.queriers.cod import CODQuery
-from Xerus.queriers.aflow import AFLOWQuery
-from Xerus.queriers.oqmd import OQMDQuery
-from Xerus.queriers.optimade import OptimadeQuery
-from Xerus.utils.cifutils import standarize, make_system, rename_multicif, get_provider
-import shutil
-import os
 import json
-from Xerus.db.localdb import LocalDB
+import os
+import shutil
 from pathlib import Path
+
+from Xerus.db.localdb import LocalDB
+from Xerus.queriers.aflow import AFLOWQuery
+from Xerus.queriers.cod import CODQuery
+from Xerus.queriers.mp import querymp
+from Xerus.queriers.optimade import OptimadeQuery
+from Xerus.queriers.oqmd import OQMDQuery
+from Xerus.utils.cifutils import (get_provider, make_system, rename_multicif,
+                                  standarize)
+
 dbhandler = LocalDB()
 abs_path = Path(__file__).parent
 proj_path = os.sep.join(str(abs_path).split(os.sep)[1:-1])
@@ -135,26 +137,30 @@ def multiquery(element_list: List[str], max_num_elem: int,  resync:bool = False)
     oqmd = OQMDQuery(element_list=element_list, dumpfolder=oqmd_path)
     oqmd.query()
     td.append(oqmd_path)
+    
 
-    # Some example OPTIMADE queries
-    print("Querying some OPTIMADE APIs")
-    cod_optimade = OptimadeQuery(
-        base_url="https://www.crystallography.net/tcod/optimade/v1/",
-        elements=element_list,
-        folder_path=Path("optimade")
-    )
-    mp_optimade = OptimadeQuery(
-        base_url="https://optimade.materialsproject.org/v1/",
-        elements=element_list,
-        folder_path=Path("optimade")
-    )
-    oqmd_optimade = OptimadeQuery(
-        base_url="https://oqmd.org/optimade/v1/",
-        elements=element_list,
-        folder_path=Path("optimade")
-    )
+    # TODO: Evaluate on how to implement each querier through optimade via the generic OptimadeQuery interface
+    # # Some example OPTIMADE queries
+    # print("Querying some OPTIMADE APIs")
+    # cod_optimade = OptimadeQuery(
+    #     base_url="https://www.crystallography.net/tcod/optimade/v1/",
+    #     elements=element_list,
+    #     folder_path=Path("optimade")
+    # )
 
-    td.append(Path("optimade"))
+    # Currently only MP works.
+    # mp_optimade = OptimadeQuery(
+    #     base_url="https://optimade.materialsproject.org/v1/",
+    #     elements=element_list,
+    #     folder_path=Path("optimade")
+    # )
+    # oqmd_optimade = OptimadeQuery(
+    #     base_url="https://oqmd.org/optimade/v1/",
+    #     elements=element_list,
+    #     folder_path=Path("optimade")
+    # )
+
+    # td.append(Path("optimade"))
 
     movecifs(dump_folders=td)
     print("Finished downloading CIFs.")

--- a/Xerus/queriers/multiquery.py
+++ b/Xerus/queriers/multiquery.py
@@ -22,6 +22,8 @@ import os
 import sys
 from pathlib import Path
 from typing import List
+
+from Xerus.queriers.optimade import OptimadeQuery
 project_path = str(Path(os.path.dirname(os.path.realpath(__file__))).parent) + os.sep # so convoluted..
 if project_path not in sys.path:
     sys.path.append(project_path)
@@ -29,6 +31,7 @@ from Xerus.queriers.mp import querymp
 from Xerus.queriers.cod import CODQuery
 from Xerus.queriers.aflow import AFLOWQuery
 from Xerus.queriers.oqmd import OQMDQuery
+from Xerus.queriers.optimade import OptimadeQuery
 from Xerus.utils.cifutils import standarize, make_system, rename_multicif, get_provider
 import shutil
 import os
@@ -132,6 +135,26 @@ def multiquery(element_list: List[str], max_num_elem: int,  resync:bool = False)
     oqmd = OQMDQuery(element_list=element_list, dumpfolder=oqmd_path)
     oqmd.query()
     td.append(oqmd_path)
+
+    # Some example OPTIMADE queries
+    print("Querying some OPTIMADE APIs")
+    cod_optimade = OptimadeQuery(
+        base_url="https://www.crystallography.net/tcod/optimade/v1/",
+        elements=element_list,
+        folder_path=Path("optimade")
+    )
+    mp_optimade = OptimadeQuery(
+        base_url="https://optimade.materialsproject.org/v1/",
+        elements=element_list,
+        folder_path=Path("optimade")
+    )
+    oqmd_optimade = OptimadeQuery(
+        base_url="https://oqmd.org/optimade/v1/",
+        elements=element_list,
+        folder_path=Path("optimade")
+    )
+
+    td.append(Path("optimade"))
 
     movecifs(dump_folders=td)
     print("Finished downloading CIFs.")

--- a/Xerus/queriers/optimade.py
+++ b/Xerus/queriers/optimade.py
@@ -71,7 +71,7 @@ class OptimadeQuery:
 
     def query(self, query_url: Union[str, None] = None) -> None:
         if not query_url:
-            query_url = f"{self.base_url}/{self.optimade_endpoint}?{self.optimade_filter}&{self.optimade_response_fields}"
+            query_url = f"{self.base_url}/{self.optimade_endpoint}?{self.optimade_filter}&{self.optimade_response_fields}&page_limit=10"
 
         response = requests.get(query_url)
         logging.info("Query %s returned status code %s", query_url, response.status_code)

--- a/Xerus/queriers/optimade.py
+++ b/Xerus/queriers/optimade.py
@@ -1,0 +1,67 @@
+"""This submodule implements the `OptimadeQuery` class, which enables filtering 
+on any crystal structure database that implements an [OPTIMADE API](https://optimade.org).
+
+"""
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import List
+project_path = str(Path(os.path.dirname(os.path.realpath(__file__))).parent) + os.sep # so convoluted..
+if project_path not in sys.path:
+    sys.path.append(project_path)
+
+import requests
+from optimade.adapters import Structure, get_cif
+
+
+class OptimadeQuery(object):
+
+    def __init__(
+        self, 
+        base_url: str, 
+        elements: List[str] = None, 
+        folder_path: os.PathLike = ""
+    ):
+        """Initialise the query objects for a given database.
+        
+        Parameters:
+            elements: The list of element symbols that define the chemical space to query.
+            base_url: The base URL of the OPTIMADE API for the database.
+
+        """
+
+        self.elements = elements
+        self.folder_path = Path(folder_path)
+        self.base_url = base_url
+        self.optimade_endpoint = "structures"
+        self.optimade_filter = "filter=elements HAS ONLY " + ",".join(f'"{e}"' for e in self.elements)
+        os.mkdir(self.folder_path, exist_ok=True)
+
+    def make_name(self, entry, meta) -> str:
+        return f'{meta["provider"]["prefix"]}_{entry["id"]}.cif'
+
+
+    def query(self, query_url: str | None) -> None:
+
+        if not query_url:
+            query_url = f"{self.base_url}/{self.optimade_endpoint}?{self.optimade_filter}"
+
+        response = requests.get(query_url)
+        logging.info("Query %s returned status code %s", query_url, response.status_code)
+        next_query_url = None
+        if response.status_code == 200:
+            data = response.json()
+            meta = data["meta"]
+            if meta["more_data_available"]:
+                next_query_url = data["links"]["next"]
+
+            structures = [Structure(**entry) for entry in data["data"]]
+
+            for structure in structures:
+                cif_fname = self.make_name(structure.entry, structure)
+                with open(self.folder_path / cif_fname, "w") as f:
+                    f.write(get_cif(structure))
+
+        if next_query_url:
+            self.query(next_query_url)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ pymongo<4
 optuna==2.4.0
 pytest>=6.2.1
 PeakUtils==1.3.3
-
+optimade~=0.16


### PR DESCRIPTION
I think this allows us to query OQMD/MP through optimade and get all the data needed to generate the structures.
Ive tested a bit with MP and OQMD, it seemed that the cifs were working correctly.
I also added and option to add extra filters as a dict in the following manner:
```python
extra_filters = {"property": "{condition}{value}"}, 
ie:
extra_filters = {"_oqmd_stability": "<0.1"}
```
I wanted to run few more tests but it seems that OQMD is specially slow today.

In the case of COD, since we cannot use "HAS ONLY" and they do not provide all the information for generating structure we can keep the 'original' for now. I will work on how to use optimade querier in the usual workflow of Xerus now. One straightfoward way is to replace my OQMD with this, if everything goes well. Another is to use optimade materials project to replace conventional one for CI tests.
